### PR TITLE
Feat: Save jwt token in store, cookie

### DIFF
--- a/src/libs/Cookie.ts
+++ b/src/libs/Cookie.ts
@@ -5,7 +5,7 @@ const cookies = new Cookies();
 /** refresh Token을 Cookie에 저장하기 위한 함수 */
 export const setRefreshToken = (refreshToken: string) => {
   const today = new Date();
-  const expireDate = today.setDate(today.getDate() + 30);
+  const expireDate = today.setDate(today.getDate() + 1);
 
   return cookies.set('refresh_token', refreshToken, {
     sameSite: true,

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -38,17 +38,17 @@ const SignIn = () => {
     console.log('email', email);
     console.log('password', password);
     // console.log('event', event);
-    const response = await logIn({ email, password });
-    const { accessToken, refreshToken } = response.data;
+    // const response = await logIn({ email, password });
+    // const { accessToken, refreshToken } = response.data;
 
-    if (response.status === 200) {
-      // cookie에 refreshToken, store에 accessToken 저장
-      setRefreshToken(refreshToken);
-      dispatch(SET_TOKEN(accessToken));
-      navigate('/main');
-    } else {
-      alert('로그인에 실패하셨습니다.');
-    }
+    // if (response.status === 200) {
+    //   // cookie에 refreshToken, store에 accessToken 저장
+    //   setRefreshToken(refreshToken);
+    //   dispatch(SET_TOKEN(accessToken));
+    //   navigate('/main');
+    // } else {
+    //   alert('로그인에 실패하셨습니다.');
+    // }
   };
 
   return (

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -17,24 +17,24 @@ const User = () => {
   const dispatch = useDispatch();
   const [modalOpen, setModalOpen] = useState(false);
 
-  const { accessToken } = useSelector((state) => state.authToken);
+  // const { accessToken } = useSelector((state) => state.authToken);
 
-  const refreshToken: string = getCookieToken();
+  // const refreshToken: string = getCookieToken();
   const logOutConfirm = () => {
     setModalOpen(false);
   };
 
-  const userlogOut = async (refreshtoken: string) => {
-    const response = await logOut({ token: refreshtoken });
+  // const userlogOut = async (refreshtoken: string) => {
+  //   const response = await logOut({ token: refreshtoken });
 
-    if (response.status) {
-      dispatch(DELETE_TOKEN());
-      removeCookieToken();
-      return navigate('/');
-    } else {
-      // 뭐하지..
-    }
-  };
+  //   if (response.status) {
+  //     dispatch(DELETE_TOKEN());
+  //     removeCookieToken();
+  //     return navigate('/');
+  //   } else {
+  //     // 뭐하지..
+  //   }
+  // };
 
   return (
     <>

--- a/src/store/api/apiSlice.ts
+++ b/src/store/api/apiSlice.ts
@@ -1,5 +1,10 @@
+<<<<<<< HEAD
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 // import { setCredentials, logOut } from "../../features/authSlice/authSlice";
+=======
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { setCredentials, logOut } from '../../features/authSlice/authSlice';
+>>>>>>> d4a9c5d (Fix: Updata refreshToken expireDate in Cookie.ts)
 
 export type FetchBaseQueryError =
   | {
@@ -15,7 +20,11 @@ export type FetchBaseQueryError =
        * * `"FETCH_ERROR"`:
        *   An error that occurred during execution of `fetch` or the `fetchFn` callback option
        **/
+<<<<<<< HEAD
       status: "FETCH_ERROR";
+=======
+      status: 'FETCH_ERROR';
+>>>>>>> d4a9c5d (Fix: Updata refreshToken expireDate in Cookie.ts)
       data?: undefined;
       error: string;
     }
@@ -26,7 +35,11 @@ export type FetchBaseQueryError =
        *   Most likely a non-JSON-response was returned with the default `responseHandler` "JSON",
        *   or an error occurred while executing a custom `responseHandler`.
        **/
+<<<<<<< HEAD
       status: "PARSING_ERROR";
+=======
+      status: 'PARSING_ERROR';
+>>>>>>> d4a9c5d (Fix: Updata refreshToken expireDate in Cookie.ts)
       originalStatus: number;
       data: string;
       error: string;
@@ -36,12 +49,17 @@ export type FetchBaseQueryError =
        * * `"CUSTOM_ERROR"`:
        *   A custom error type that you can return from your `queryFn` where another error might not make sense.
        **/
+<<<<<<< HEAD
       status: "CUSTOM_ERROR";
+=======
+      status: 'CUSTOM_ERROR';
+>>>>>>> d4a9c5d (Fix: Updata refreshToken expireDate in Cookie.ts)
       data?: unknown;
       error: string;
     };
 
 const baseQuery = fetchBaseQuery({
+<<<<<<< HEAD
   baseUrl: "http://localhost:5173", // baseUrl 통일예정
   credentials: "include",
   prepareHeaders: (headers, { getState }) => {
@@ -49,12 +67,22 @@ const baseQuery = fetchBaseQuery({
     // if (token) {
     //   headers.set("authorization", `Bearer ${token}`);
     // }
+=======
+  baseUrl: 'http://localhost:5173', // baseUrl 통일예정
+  credentials: 'include',
+  prepareHeaders: (headers, { getState }) => {
+    const token = getState().auth.token;
+    if (token) {
+      headers.set('authorization', `Bearer ${token}`);
+    }
+>>>>>>> d4a9c5d (Fix: Updata refreshToken expireDate in Cookie.ts)
     return headers;
   },
 });
 
 const baseQueryWithReauth = async (args, api, extraOptions) => {
   let result = await baseQuery(args, api, extraOptions);
+<<<<<<< HEAD
   // if (result?.error?.originalStatus === 403) {
   //   console.log("sending refresh token");
   //   // send refresh token to get new access token
@@ -70,6 +98,23 @@ const baseQueryWithReauth = async (args, api, extraOptions) => {
   //     api.dispatch(logOut());
   //   }
   // }
+=======
+  if (result?.error?.originalStatus === 403) {
+    console.log('sending refresh token');
+    // send refresh token to get new access token
+    const refreshResult = await baseQuery('/refresh', api, extraOptions);
+    console.log(refreshResult);
+    if (refreshResult?.data) {
+      const user = api.getState().auth.user;
+      // store the new token
+      api.dispatch(setCredentials({ ...refreshResult.data, user }));
+      // retry the original query with new access token
+      result = await baseQuery(args, api, extraOptions);
+    } else {
+      api.dispatch(logOut());
+    }
+  }
+>>>>>>> d4a9c5d (Fix: Updata refreshToken expireDate in Cookie.ts)
 
   return result;
 };

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,8 +1,8 @@
-import { cartApi } from "./api/cartApiSlice";
-import { orderApi } from "./api/orderApiSlice";
-import { wishlistApi } from "./api/wishlistApiSlice";
-import { configureStore } from "@reduxjs/toolkit";
-import authReducer from "../features/authSlice/authSlice";
+import { cartApi } from './api/cartApiSlice';
+import { orderApi } from './api/orderApiSlice';
+import { wishlistApi } from './api/wishlistApiSlice';
+import { configureStore } from '@reduxjs/toolkit';
+import authReducer from '../features/authSlice/authSlice';
 
 const store = configureStore({
   reducer: {
@@ -12,11 +12,7 @@ const store = configureStore({
     authToken: authReducer,
   },
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat([
-      cartApi.middleware,
-      orderApi.middleware,
-      wishlistApi.middleware,
-    ]),
+    getDefaultMiddleware().concat([cartApi.middleware, orderApi.middleware, wishlistApi.middleware]),
 });
 
 export default store;


### PR DESCRIPTION
## ✔️ 체크사항

- [x] 가장 최근 merge를 pull 받고 진행하는 것이 맞나요? 👉[최근 pr 확인 링크](https://github.com/FastcampusMini/mini-project-fe/pulls?q=is%3Apr+is%3Aclosed)👈
- [x] merge 하는 곳이 develop 브랜치가 맞나요?
- [x] 노션 진행상황 및 라이브러리 업데이트를 진행했나요? 👉[노션 진행상황](https://www.notion.so/0f88e1584a324feea401e760d074f2b3?v=c92f8c959c41453daafdc207c6933ee5&pvs=4) / [노션 라이브러리](https://www.notion.so/KDT3-Mini-Project-FE-8c190ddbb4db4516be27f5cadf3beb78?pvs=4)👈

## 🔊 팀원들에게 알릴 사항

- refreshToken은 cookie, accessToken은 store에 저장
- axios interceptors(인터셉터)에서 timeout 오류 처리 추후 도입 예정

## 🌐 담당 구역 작업

[signIn]

- 로그인 시, jwt token data 받아와서 저장하기


## 🌐 공통 폴더 구조 및 파일에서 변경된 것

[store]

- reducer 추가